### PR TITLE
CI: Update discord ping workflow

### DIFF
--- a/.github/workflows/discord_ping_on_release.yml
+++ b/.github/workflows/discord_ping_on_release.yml
@@ -10,13 +10,33 @@ jobs:
     steps:
       - uses: sarisia/actions-status-discord@v1
         if: always()
+        id: webhook # set id to reference output payload later
         with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          username: ReVanced Extended
-          color: 0xff5252
+          ack_no_webhook: true # suppress warning
           nodetail: true
           notimestamp: true
-          content: "<@&1271215152246689904>"
-          title: "ARSClib patches `${{ github.event.release.tag_name }}` has been released!"
+          
+          username: ReVanced Extended
+          content: "<@&1271197877724643461>"
+          title: "ARSCLib patches `${{ github.event.release.tag_name }}` has been released!"
           description: |
-            Click [here](${{ github.event.release.html_url }}) to read the changelog.
+            Click [here](${{ github.event.release.html_url }}) to read the changelog and release notes.
+
+      - run: npm install axios
+      - uses: actions/github-script@v7
+        env:
+          WEBHOOK_PAYLOAD: ${{ steps.webhook.outputs.payload }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        with:
+          script: |
+            const axios = require("axios")
+
+            const { WEBHOOK_PAYLOAD, WEBHOOK_URL } = process.env
+
+            const payload = JSON.parse(WEBHOOK_PAYLOAD)
+
+            // remove the color field to make it transparent
+            delete payload.embeds[0].color
+
+            // send to Discord 
+            axios.post(WEBHOOK_URL, payload)


### PR DESCRIPTION
This makes the workflow identical to the workflow in the revanced-patches repo except that the title of the message says "ARSCLib patches ..." instead of just "Patches..."

 https://github.com/inotia00/revanced-patches/blob/revanced-extended/.github/workflows/discord_ping_on_release.yml

You will need to update the `DISCORD_WEBHOOK_URL` secret in the repository settings to the value I sent in our chat.